### PR TITLE
Updated HttpToSocks5Proxy

### DIFF
--- a/Telegram.Bot.Examples.DotNetCoreWebHook/Telegram.Bot.Examples.DotNetCoreWebHook.csproj
+++ b/Telegram.Bot.Examples.DotNetCoreWebHook/Telegram.Bot.Examples.DotNetCoreWebHook.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HttpToSocks5Proxy" Version="1.0.2" />
+    <PackageReference Include="HttpToSocks5Proxy" Version="1.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.7" />
     <PackageReference Include="Telegram.Bot" Version="14.3.0" />
   </ItemGroup>


### PR DESCRIPTION
Updated HttpToSocks5Proxy to 1.0.5 because previous versions have broken username/password authentication