### PR TITLE
Bug fix: Location null-check in message text.

### DIFF
--- a/FSharp.Examples.Polling/Services/Internal/UpdateHandlerFuncs.fs
+++ b/FSharp.Examples.Polling/Services/Internal/UpdateHandlerFuncs.fs
@@ -154,7 +154,7 @@ module UpdateHandlerFuncs =
     logInfo logger $"Receive message type: {message.Type}"
 
     match message.Text with
-    | text when message.Text <> "" ->
+    | text when (not (String.IsNullOrEmpty message.Text)) ->
         // We use tryHead here just in case we get an empty
         // response from the user
         match text.Split(' ') |> Array.tryHead with


### PR DESCRIPTION
Location push had a bug where text was null instead of a "" (others had ""). This code now fixes that error.